### PR TITLE
Update Header.vue

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -103,7 +103,7 @@
           href="https://www.spigotmc.org/resources/advancedgui-interactive-itemframe-guis.83636/"
           target="_blank"
           rel="noopener noreferrer"
-          >SpigtMC</a
+          >SpigotMC</a
         >. <br />
         The code of this edtor is open-srouce on
         <a


### PR DESCRIPTION
"SpigtMC" to "SpigotMC", fixes Spelling mistake in the about popup