### PR TITLE
Fix spelling mistake in ProjectSerializationHandler.ts at line 156

### DIFF
--- a/src/utils/handler/ProjectSerializationHandler.ts
+++ b/src/utils/handler/ProjectSerializationHandler.ts
@@ -153,7 +153,7 @@ export async function downloadProjectFile(savepoint: Project, key: string) {
     );
     loading(false);
   } catch (exc) {
-    const errorText = `Error durring export: ${exc.message || exc}`;
+    const errorText = `Error during export: ${exc.message || exc}`;
     const licenseError =
       errorText.toLocaleLowerCase().includes("licence") ||
       errorText.toLocaleLowerCase().includes("license");


### PR DESCRIPTION
"durring" ⇾ "during" ;)
I know this is kinda petty, but I was looking through the code (learning Vue since 5 or so months and wanted to look at some complicated stuff) and saw that. Thought why not fix that really quick :)